### PR TITLE
Minor modifications to `matmul_codegen_spec_pad.mlir`.

### DIFF
--- a/transform_dialect/examples/accel/matmul_codegen_spec_pad.mlir
+++ b/transform_dialect/examples/accel/matmul_codegen_spec_pad.mlir
@@ -11,7 +11,7 @@
 //     --iree-stream-transformation-pipeline \
 //     --iree-hal-configuration-pipeline | \
 //   ${IREE_DIR}/build/tools/iree-opt \
-//      --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))' \
+//      --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target, builtin.module(func.func(iree-hoist-statically-bound-allocations)))))' \
 //      --iree-codegen-llvmcpu-use-transform-dialect=${IREE_SAMPLES_DIR}/transform_dialect/examples/accel/matmul_codegen_spec_pad.mlir
 // ```
 
@@ -33,38 +33,38 @@ module attributes { transform.with_named_sequence } {
   ^bb1(%variant_op: !transform.any_op):
     %matmul = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!transform.any_op) -> !transform.any_op
 
-    // First level tile to forall with tile_sizes [32, 16].
+    // First level tile to forall with tile_sizes [16, 32].
     %forall, %tiled_matmul =
-      transform.structured.tile_to_forall_op %matmul tile_sizes [32, 16]
-        ( mapping = [#gpu.block<x>, #gpu.block<y>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+      transform.structured.tile_to_forall_op %matmul tile_sizes [16, 32]
+        ( mapping = [#gpu.block<y>, #gpu.block<x>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
     transform.iree.populate_workgroup_count_region_using_num_threads_slice %forall
       : (!transform.any_op) -> ()
 
     // Tile reduction dimension.
     %tiled_reduction, %loop =
-      transform.structured.tile %tiled_matmul [0, 0, 16]
+      transform.structured.tile %tiled_matmul [0, 0, 8]
       : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
     // Pad operation.
-    %padded, %pad = transform.structured.pad %tiled_reduction {
+    %padded, %pad, %__ = transform.structured.pad %tiled_reduction {
       padding_values=[0.0 : f32, 0.0 : f32, 0.0 : f32],
       padding_dimensions=[0, 1, 2],
       pack_paddings=[1, 1, 0],
       copy_back_op="none"
-    } : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    } : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
 
-    // Second level tile to forall with tile_sizes [5, 10].
+    // Second level tile to forall with tile_sizes [8, 8].
     %forall_1, %tiled_matmul_1 =
-      transform.structured.tile_to_forall_op %padded tile_sizes [5, 10]
-        ( mapping = [#gpu.thread<x>, #gpu.thread<y>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+      transform.structured.tile_to_forall_op %padded tile_sizes [8, 8]
+        ( mapping = [#gpu.thread<y>, #gpu.thread<x>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
     // Pad operation.
-    %padded_1, %pad_1 = transform.structured.pad %tiled_matmul_1 {
+    %padded_1, %pad_1, %_ = transform.structured.pad %tiled_matmul_1 {
       padding_values=[0.0 : f32, 0.0 : f32, 0.0 : f32],
       padding_dimensions=[0, 1, 2],
       pack_paddings=[0, 0, 1],
       copy_back_op="none"
-    } : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    } : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
 
     // Clean up.
     transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
@@ -76,6 +76,7 @@ module attributes { transform.with_named_sequence } {
     // Post-bufferization mapping workgroup.
     %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3 : (!transform.any_op) -> !transform.any_op
     transform.iree.forall_to_workgroup %memref_func : (!transform.any_op) -> ()
-    transform.iree.map_nested_forall_to_gpu_threads %memref_func workgroup_dims = [7, 2, 1] subgroup_size = 8 : (!transform.any_op) -> ()
+    transform.iree.map_nested_forall_to_gpu_threads %memref_func workgroup_dims = [4, 2, 1] subgroup_size = 1 : (!transform.any_op) -> ()
+    transform.iree.hoist_static_alloc %memref_func : (!transform.any_op) -> ()
   }
 }


### PR DESCRIPTION
- Make "y" the outermost distribution dimension, and "x" the innermost
- Make tile sizes for local divide the tile sizes for shared
- Add a pass to hoist the static allocations to the "example script header".